### PR TITLE
fix: 404 not found https://linuxfirstmint.github.io/web_learning_notes/doc/webhint_viewport.md

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -1,3 +1,3 @@
 # Web Learning Notes
 
-- [viewport 警告と meta タグ](doc/webhint_viewport.md)
+- [viewport 警告と meta タグ](webhint_viewport.md)


### PR DESCRIPTION
Fixes #7 docs/index.mdのノートへのリンク先を"webhint_viewport.md"に変更した